### PR TITLE
Use a go markdown library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # Wiki
 
-`wiki` finds every markdown file inside the current or given source directory and builds them into HTML files in a wiki directory.
+`wiki` finds every markdown file inside the current or given source
+directory and builds them into HTML files in a wiki directory.
 
-It launches a file server so it can be accessed in a browser and watched for file changes.  
+It launches a file server so it can be accessed in a browser and watched
+for file changes.
 
 When a file changes it's built into HTML again.
+
+## Dependedncies
+
+  * markdown library: https://github.com/gomarkdown/markdown

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,9 @@ module github.com/hmatheisen/wiki
 
 go 1.20
 
-require golang.org/x/sync v0.3.0
+require (
+	golang.org/x/sync v0.3.0
+	golang.org/x/text v0.11.0
+)
+
+require github.com/gomarkdown/markdown v0.0.0-20230716120725-531d2d74bc12

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,6 @@
+github.com/gomarkdown/markdown v0.0.0-20230716120725-531d2d74bc12 h1:uK3X/2mt4tbSGoHvbLBHUny7CKiuwUip3MArtukol4E=
+github.com/gomarkdown/markdown v0.0.0-20230716120725-531d2d74bc12/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
 golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
+golang.org/x/text v0.11.0 h1:LAntKIrcmeSKERyiOh0XMV39LXS8IE9UL2yP7+f5ij4=
+golang.org/x/text v0.11.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=


### PR DESCRIPTION
Instead of using an external binary, instead use a go markdown library to render.

As an aside, thanks, this is nifty.

You might want to look at [cobra](https://github.com/spf13/cobra) to get some options to let users tweak rendering, pick a different "wiki" directory, port, etc. Might also look at [cashier](https://github.com/nsheridan/cashier) for an example of how to spin up a browser to view the site.

Also, there are some fake filesystems you can use where you can put the entire site in memory and serve from there.